### PR TITLE
Posts pathmodule

### DIFF
--- a/server/routes/posts.routes.js
+++ b/server/routes/posts.routes.js
@@ -111,7 +111,7 @@ router.post('/create', upload.single('img'), async function (req, res, next) {
 ;       const {content, title} = req.body;
         const authData = await User.findOne({email});
         // console.log("--------------------\n\n\n", req.body, "\n2.\n", title, "\n4\n", content);
-        const url = pathmodule.join(pathmodule.dirname(req.file.path), pathmodule.basename(req.file.path));
+        const url = req.file.destination + pathmodule.basename(req.file.path);
         await Post.create({
             title: title,
             content: content,

--- a/server/routes/posts.routes.js
+++ b/server/routes/posts.routes.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import multer from 'multer';
 import { Post, User, Upment, Downment } from '../models/index.js';
+import pathmodule from 'path';
 
 export const path = '/posts';
 export const router = Router();
@@ -42,31 +43,26 @@ router.get("/list", async (req, res, next) => {
 router.get("/list/:shortId", async (req, res, next) => {
     let {shortId} = req.params;
     try {
-        let data = await Post.findOne({shortId})
+        let data = await Post.findOne({shortId, show: true})
             .populate("author")
             .populate([
                 {
                     path: "comments",
                     model: "Upment",
-                    match: { show: true },
                     populate: {
                         path: "comments author",
-                        match: { show: true },
                         
                     },
                 },
                 {
                     path: "comments",
                     model: "Upment",
-                    match: { show: true },
                     populate: {
                         path: "comments",
                         model: "Downment",
-                        match: { show: true },
                         populate: {
                             path: "author",
                             model: "User",
-                            match: { show: true },
                         }
                     },
                 },
@@ -74,30 +70,25 @@ router.get("/list/:shortId", async (req, res, next) => {
         // 사용자와 게시글 작성자 비교
     if (req.tokenInfo.email !== data.author.email) {
         await Post.updateOne({ shortId }, { $inc: { views: 1}});
-        data = await Post.findOne({ shortId })
+        data = await Post.findOne({ shortId, show: true })
             .populate("author")
             .populate([
                 {
                     path: "comments",
-                    match: { show: true },
                     model: "Upment",
                     populate: {
                         path: "comments author",
-                        match: { show: true },
                     },
                 },
                 {
                     path: "comments",
-                    match: { show: true },
                     model: "Upment",
                     populate: {
                         path: "comments",
-                        match: { show: true },
                         model: "Downment",
                         populate: {
                             path: "author",
                             model: "User",
-                            match: { show: true },
                         }
                     },
                 },
@@ -120,12 +111,13 @@ router.post('/create', upload.single('img'), async function (req, res, next) {
 ;       const {content, title} = req.body;
         const authData = await User.findOne({email});
         // console.log("--------------------\n\n\n", req.body, "\n2.\n", title, "\n4\n", content);
+        const url = pathmodule.join(pathmodule.dirname(req.file.path), pathmodule.basename(req.file.path));
         await Post.create({
             title: title,
             content: content,
             postType: 2,
             img: {
-                url: req.file.path,
+                url: url,
             },
             author: authData
         });
@@ -148,7 +140,7 @@ router.post('/create', upload.single('img'), async function (req, res, next) {
         if (tokenInfo.email !== postUserId.author.email) {
             return next(new Error("작성자가 아닙니다!"));
         }
-        await Post.deleteOne({shortId});
+        await Post.updateOne({ shortId }, {show: false});
         res.status(200).json({
             result: '삭제가 완료 되었습니다.'
         })


### PR DESCRIPTION
## 변경점
- closet과 market의 update api에서 수정해주신 show 관련 업데이트를 반영했습니다.
## url issue
- 민재님께서 notion에 올려주신 코드: url = "images/" + pathModule.basename(req.file.path); 로 시험한 결과 제대로 업로드되었습니다.
- 그러나, 현재 main 파일에 있는 코드로 실행할 경우 이전과 같은 오류가 발생했습니다. 
- 왜 그러한 지는 모르겠으나 pathmodule.join()을 하면 윈도우를 인식하지 못하고, 여전히 경로를 images\로 설정합니다.
- 따라서, req.file 객체의 destination 속성을 사용해서 해결했으나 맥에서는 작동을 제대로 할 지는 모르겠습니다..